### PR TITLE
Prevent root tabs from showing a deep-link back button

### DIFF
--- a/lib/components/lalo_app_bar.dart
+++ b/lib/components/lalo_app_bar.dart
@@ -9,6 +9,7 @@ class LaloAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
+      automaticallyImplyLeading: false,
       title: Text(name),
       actions: [
         Padding(

--- a/test/components/lalo_app_bar_test.dart
+++ b/test/components/lalo_app_bar_test.dart
@@ -1,0 +1,45 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lalo/components/lalo_app_bar.dart';
+import 'package:lalo/services/globals.dart' as globals;
+
+class _FakeUser implements User {
+  @override
+  String? get displayName => 'Test User';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  setUp(() {
+    globals.user = _FakeUser();
+  });
+
+  tearDown(() {
+    globals.user = null;
+  });
+
+  testWidgets('does not infer a back button when another route is below it', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: Text('route below')),
+      ),
+    );
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (_) => const Scaffold(appBar: LaloAppBar(name: 'Home')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BackButton), findsNothing);
+    expect(find.text('Home'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Prevent the top-level Home and More tabs from showing a misleading back button after the app is launched from an invite deep link.

## Changes

- Set the shared root `LaloAppBar` to opt out of Flutter's automatically inferred leading widget.
- Added widget coverage for the navigator state where another route remains beneath the root UI.
- Kept invite processing unchanged and preserved inferred back navigation on pushed destinations such as Profile and Feedback.

## Tests

- `dart format --output=none --set-exit-if-changed lib/components/lalo_app_bar.dart test/components/lalo_app_bar_test.dart`
- `flutter test test/components/lalo_app_bar_test.dart`
- `flutter analyze`
- `flutter build web`

## Notes

- Manual end-to-end deep-link validation on a configured Android device and authenticated web session was not available in this environment. The regression test reproduces the relevant stacked-route navigation state.

Closes #65